### PR TITLE
Make boostrap manage aws-auth by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.55.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.56.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.18.1 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.48.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.16.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.17.0 |
 
 ## Modules
 
@@ -60,6 +60,7 @@ No requirements.
 | <a name="input_enable_bastion"></a> [enable\_bastion](#input\_enable\_bastion) | True if bastion host should be created | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name | `string` | n/a | yes |
 | <a name="input_logs_retention_days"></a> [logs\_retention\_days](#input\_logs\_retention\_days) | Log retention in days | `number` | `14` | no |
+| <a name="input_manage_aws_auth_configmap"></a> [manage\_aws\_auth\_configmap](#input\_manage\_aws\_auth\_configmap) | Should Terraform manage aws\_auth ConfigMap used for setting up cluster access | `bool` | `true` | no |
 | <a name="input_org"></a> [org](#input\_org) | Organization name - part of other resource names | `string` | `"terraform"` | no |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `string` | `"eu-central-1"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | VPC CIDR address | `string` | `"10.0.0.0/16"` | no |

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ module "eks" {
   fargate_profiles = var.eks_cluster_fargate_profiles
 
   # aws-auth configmap
-  manage_aws_auth_configmap = true
+  manage_aws_auth_configmap = var.manage_aws_auth_configmap
   aws_auth_roles            = var.eks_cluster_auth_role
   aws_auth_users            = var.eks_cluster_auth_user
 

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ module "eks" {
   fargate_profiles = var.eks_cluster_fargate_profiles
 
   # aws-auth configmap
-  manage_aws_auth_configmap = false
+  manage_aws_auth_configmap = true
   aws_auth_roles            = var.eks_cluster_auth_role
   aws_auth_users            = var.eks_cluster_auth_user
 

--- a/variables.tf
+++ b/variables.tf
@@ -185,3 +185,10 @@ variable "eks_single_az" {
   type        = bool
   default     = false
 }
+
+variable "manage_aws_auth_configmap" {
+  description = "Should Terraform manage aws_auth ConfigMap used for setting up cluster access"
+  type        = bool
+  default     = true
+}
+


### PR DESCRIPTION
In the bootstrap code example we're setting up users that should be added to aws-auth ConfigMap, however the option to enable this is turned off. I changed it to a variable that is set to `true` by default, but can be disabled by the module user.