### PR TITLE
Conditional creation of node sg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,12 +47,12 @@ module "eks" {
   vpc_id     = var.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
   subnet_ids = var.create_vpc ? concat(module.vpc[0].public_subnets, module.vpc[0].private_subnets) : concat(var.public_subnet_ids, var.private_subnet_ids)
 
-  cluster_endpoint_private_access = var.eks_cluster_endpoint_access.enable_private_access
-  cluster_endpoint_public_access  = var.eks_cluster_endpoint_access.enable_public_access
-  create_cluster_security_group   = true
-  create_node_security_group      = true
-  cluster_enabled_log_types       = var.eks_cluster_log_types
-  cluster_addons                  = merge(var.eks_default_cluster_addons, var.eks_additional_cluster_addons)
+  cluster_endpoint_private_access            = var.eks_cluster_endpoint_access.enable_private_access
+  cluster_endpoint_public_access             = var.eks_cluster_endpoint_access.enable_public_access
+  create_cluster_security_group              = true
+  create_node_security_group                 = var.eks_create_node_security_group
+  cluster_enabled_log_types                  = var.eks_cluster_log_types
+  cluster_addons                             = merge(var.eks_default_cluster_addons, var.eks_additional_cluster_addons)
 
 
   # EKS Managed Node Group(s)

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,12 @@ variable "eks_cluster_auth_role" {
   default = []
 }
 
+variable "eks_create_node_security_group" {
+  description = "Should we create a node security group?"
+  type        = bool
+  default     = true
+}
+
 variable "eks_default_cluster_addons" {
   description = "Map of default cluster addon configurations to enable for the cluster."
   type        = any


### PR DESCRIPTION
Add condition so we can disable creation of node group sg.

Reason:
Unable to deploy aws-loadbalancer-controller on smsportal dev:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1897

Risk: 
None, default module behaviour does not change

Rollback:
Revert commit, remove (or mark as broken) related releases.
